### PR TITLE
feat: home sync

### DIFF
--- a/src/components/PresetCard.tsx
+++ b/src/components/PresetCard.tsx
@@ -15,10 +15,13 @@ const useStyles = createStyles(({ token, css }) => {
       background: ${token.colorBgContainer};
     `,
     title: css`
-      margin-bottom: 24px;
       color: ${token.colorTextLabel};
       font-size: 16px;
-      line-height: 22px;
+      letter-spacing: 0;
+    `,
+    subTitle: css`
+      color: ${token.colorTextSecondary};
+      font-size: 14px;
       letter-spacing: 0;
     `,
   };
@@ -28,10 +31,12 @@ export interface PresetCardProps {
   children?: React.ReactNode;
   title?: React.ReactNode;
   style?: React.CSSProperties;
+  subTitle?: React.ReactNode;
 }
 
 export default function PresetCard({
   title,
+  subTitle,
   children,
   style = {},
 }: PresetCardProps) {
@@ -40,13 +45,27 @@ export default function PresetCard({
   return (
     <div className={styles.container} style={style}>
       {title && (
-        <Typography.Title
-          level={3}
-          className={styles.title}
-          style={{ fontSize: 16, marginBottom: '1rem' }}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginBottom: '1rem',
+          }}
         >
-          {title}
-        </Typography.Title>
+          <Typography.Title
+            level={3}
+            className={styles.title}
+            style={{ fontSize: 16, marginBottom: 0, flex: 1 }}
+          >
+            {title}
+          </Typography.Title>
+          <Typography.Text
+            style={{ fontSize: 14, marginBottom: 0, marginTop: 0 }}
+            className={styles.subTitle}
+          >
+            {subTitle}
+          </Typography.Text>
+        </div>
       )}
       {children}
     </div>

--- a/src/components/RecentVersion.tsx
+++ b/src/components/RecentVersion.tsx
@@ -1,0 +1,126 @@
+'use client';
+import { Button, Space, Tag, Tooltip, Typography } from 'antd';
+import React from 'react';
+import { createStyles } from 'antd-style';
+import {
+  PackageManifest,
+  useVersionTags,
+  useVersions,
+} from '@/hooks/useManifest';
+import dayjs from 'dayjs';
+import Link from 'next/link';
+
+const useStyles = createStyles(({ token, css }) => {
+  return {
+    container: css`
+      position: relative;
+      padding: 20px 24px;
+      overflow: hidden;
+      border: 1px solid ${token.colorBorder};
+      border-radius: 8px;
+      box-shadow: ${token.boxShadowTertiary};
+      background: ${token.colorBgContainer};
+    `,
+    title: css`
+      display: flex;
+      align-items: center;
+    `,
+    viewAll: css`
+      padding-top: 16px;
+      text-align: center;
+      width: 100%;
+      display: block;
+    `,
+    date: css`
+      color: ${token.colorTextSecondary};
+      font-weight: normal;
+      font-size: 14px;
+      letter-spacing: 0;
+      opacity: 0.65;
+    `,
+    content: css`
+      flex: 1;
+      color: ${token.colorTextBase};
+      font-size: 16px;
+      line-height: 22px;
+      letter-spacing: 0;
+    `,
+    newTag: css`
+      margin-left: 8px;
+      color: ${token.colorError};
+      font-weight: normal;
+      font-size: 14px;
+    `,
+    version: css`
+      padding-bottom: 4px;
+      padding-top: 16px;
+      border-bottom: 1px solid ${token.colorBorder};
+    `,
+  };
+});
+
+export interface PresetCardProps {
+  pkg: PackageManifest;
+}
+
+export default function RecentVersion({ pkg }: PresetCardProps) {
+  const versions = useVersions(pkg);
+  const tags = useVersionTags(pkg);
+  const { styles } = useStyles();
+
+  return (
+    <div style={{ overflow: 'hidden', minHeight: 90 }}>
+      {versions.slice(0, 4).map((item, index) => {
+        const publishDate = dayjs(item.publish_time);
+        const isNew = publishDate.isAfter(dayjs().add(-14, 'day'));
+        const deprecated = item.deprecated;
+
+        return (
+          <div className={styles.version} key={index}>
+            <Link href={`/package/${pkg?.name}?version=${item.version}`}>
+              <Typography.Title level={3} className={styles.title}>
+                <span
+                  className={styles.content}
+                  style={
+                    deprecated
+                      ? {
+                          color: 'rgba(0,0,0,.25)',
+                          textDecoration: 'line-through',
+                        }
+                      : {}
+                  }
+                >
+                  <Space size='small'>
+                    {item.version}
+                    {tags[item.version] ? (
+                      tags[item.version].map((tag) => (
+                        <Tag key={tag} color='lime'>
+                          {tag}
+                        </Tag>
+                      ))
+                    ) : (
+                      <></>
+                    )}
+                  </Space>
+                  {isNew && !deprecated ? (
+                    <span className={styles.newTag}>New</span>
+                  ) : null}
+                </span>
+                <Tooltip title={publishDate.format('YYYY-MM-DD HH:mm:ss Z')}>
+                  <span className={styles.date}>
+                    {publishDate.format('YYYY-MM-DD')}
+                  </span>
+                </Tooltip>
+              </Typography.Title>
+            </Link>
+          </div>
+        );
+      })}
+
+      {/* 查看全部 */}
+      <Link className={styles.viewAll} href={`/package/${pkg!.name}/versions`}>
+        <Button>查看全部</Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Sync.tsx
+++ b/src/components/Sync.tsx
@@ -13,10 +13,10 @@ export default function Sync({ pkgName }: SyncProps) {
 
   async function showLog(id: string) {
     modal.success({
-      title: '同步日志',
+      title: '等待调度',
       content: (
         <>
-          创建同步任务成功，正在等待调度，通常需要几十秒钟的时间
+          创建同步任务成功，正在等待调度，如遇日志 404 请稍后刷新重试，通常需要几十秒钟的时间
           <Link
             target='_blank'
             href={`https://registry.npmmirror.com/-/package/${pkgName}/syncs/${id}/log`}

--- a/src/components/SyncAlert.tsx
+++ b/src/components/SyncAlert.tsx
@@ -21,7 +21,7 @@ export default function SyncAlert({pkg, needSync}: SyncAlertProps) {
   const registry = pkg?._source_registry_name;
   // const { needSync, isLoading } = useNeedSync(pkg!, registry);
   let type: AlertProps['type'] = 'success';
-  let message = '版本已同步';
+  let message = '所有版本均已同步';
   let sourceLink;
   let description;
 

--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { orderBy } from 'lodash';
 import useSwr from 'swr';
+import dayjs from "dayjs";
 
 export interface NpmPackageVersion {
   name: string;
@@ -46,10 +47,10 @@ export function useVersions(manifest: PackageManifest): NpmPackageVersion[] {
       }
       return {
         ...item,
-        publish_time: new Date(item._cnpmcore_publish_time).valueOf(),
+        publish_time: new Date(item._cnpmcore_publish_time || item.publish_time).valueOf(),
       };
     });
-    return orderBy(patchedVersions, 'publish_time', 'desc');
+    return patchedVersions.sort((a, b) => dayjs(a.publish_time).isAfter(b.publish_time) ? -1 : 1);
   }, [manifest]);
 }
 

--- a/src/pages/api/info.ts
+++ b/src/pages/api/info.ts
@@ -57,6 +57,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const data = {
       name: pkg.name,
       maintainers,
+      description: pkg.description,
       repository,
       'dist-tags': pkg['dist-tags'],
       versions: simpleVersions,

--- a/src/pages/package/[...slug]/index.tsx
+++ b/src/pages/package/[...slug]/index.tsx
@@ -121,7 +121,7 @@ export default function PackagePage({
         <section style={{ paddingLeft: 16 }}>
           <CustomTabs activateKey={type} pkg={resData}></CustomTabs>
         </section>
-        <main>
+        <main style={{ minHeight: 'calc( 100vh - 110px )' }}>
           <Component
             manifest={resData}
             version={version}

--- a/src/slugs/files/index.tsx
+++ b/src/slugs/files/index.tsx
@@ -34,7 +34,7 @@ const Viewer = ({ manifest, version }: PageProps) => {
   }
 
   return (
-    <div style={{ display: 'flex', marginTop: -16 }}>
+    <div style={{ display: 'flex', marginTop: -16, minHeight: '100%' }}>
       <Sidebar>
         <FileTree
           rootDir={rootDir}

--- a/src/slugs/home/index.tsx
+++ b/src/slugs/home/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Col, Row, Space, Typography } from 'antd';
+import { Button, Col, Row, Space, Tooltip, Typography } from 'antd';
 import SizeContainer from '@/components/SizeContainer';
 import PresetCard from '@/components/PresetCard';
 import ReadmeContent from '@/components/ReadmeContent';
@@ -9,12 +9,15 @@ import AdBanner from '@/components/AdBanner';
 import AdVPS from '@/components/AdVPS';
 import { PageProps } from '@/pages/package/[...slug]';
 import { createStyles } from 'antd-style';
+import RecentVersion from '@/components/RecentVersion';
+import Sync from '@/components/Sync';
+import { QuestionCircleFilled } from '@ant-design/icons';
 
 const useStyles = createStyles(({ token, css }) => {
   return {
     homeCon: css`
       position: relative;
-      padding-top: 80px;
+      padding-top: 48px;
       overflow: hidden;
     `,
     tagCon: css`
@@ -37,7 +40,7 @@ const useStyles = createStyles(({ token, css }) => {
   };
 });
 
-export default function Home({ manifest, version }: PageProps) {
+export default function Home({ manifest, version, additionalInfo: needSync }: PageProps) {
   const pkg = manifest;
   const tags: string[] = pkg?.keywords || [];
   const { styles: style } = useStyles();
@@ -60,6 +63,7 @@ export default function Home({ manifest, version }: PageProps) {
       </Col>
       <Col flex='0 0 378px'>
         <Space direction={'vertical'} size='middle' style={{ minWidth: 378 }}>
+          <AdVPS />
           {manifest.maintainers?.length > 0 && (
             <PresetCard title='项目成员'>
               <ContributorContent members={manifest.maintainers} />
@@ -71,7 +75,18 @@ export default function Home({ manifest, version }: PageProps) {
               dist={manifest.versions?.[version!]?.dist}
             />
           </PresetCard>
-          <AdVPS />
+          <PresetCard
+            title='最近更新'
+            subTitle={
+              !needSync ? (
+                <Sync pkgName={pkg.name} />
+              ) : (
+                <Tooltip title={'和源站数据比对一致'}>无需同步</Tooltip>
+              )
+            }
+          >
+            <RecentVersion pkg={pkg} />
+          </PresetCard>
         </Space>
       </Col>
     </Row>
@@ -84,7 +99,9 @@ export default function Home({ manifest, version }: PageProps) {
         style={{ position: 'relative', marginTop: 0 }}
       >
         <div>
-          <Typography.Title>{pkg!.name}</Typography.Title>
+          <Typography.Title>
+            {pkg!.name}
+          </Typography.Title>
           <Typography.Paragraph ellipsis>
             {pkg!.description}
           </Typography.Paragraph>

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -221,7 +221,7 @@ function VersionsList({
                     ) : null}
                     <Tooltip
                       title={dayjs(item.publish_time).format(
-                        'YYYY-MM-DD HH:mm:SS'
+                        'YYYY-MM-DD HH:mm:ss Z'
                       )}
                     >
                       {dayjs(item.publish_time).format('YYYY-MM-DD')}


### PR DESCRIPTION
> closes #15 
* 🧶 包首页添加 「最近更新」区块
* 🧶 添加同步按钮入口，自动判断包状态
* 🐞 修复包首页描述信息
* 🐞 修复产物预览页页脚加载时高度展示异常

![image](https://github.com/cnpm/cnpmweb/assets/5574625/ca865705-b6fa-4efd-8e9e-b3c0791e4857)

![image](https://github.com/cnpm/cnpmweb/assets/5574625/7e49080d-b0e0-4e6f-a5b8-7bff6f8ffd29)
