### PR TITLE
feat: overflow tags

### DIFF
--- a/src/components/RecentVersion.tsx
+++ b/src/components/RecentVersion.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/hooks/useManifest';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import VersionTags from './VersionTags';
 
 const useStyles = createStyles(({ token, css }) => {
   return {
@@ -90,17 +91,15 @@ export default function RecentVersion({ pkg }: PresetCardProps) {
                       : {}
                   }
                 >
-                  <Space size='small'>
+                  <Space size='small' style={{ flex: 1 }}>
                     {item.version}
-                    {tags[item.version] ? (
-                      tags[item.version].map((tag) => (
-                        <Tag key={tag} color='lime'>
-                          {tag}
-                        </Tag>
-                      ))
-                    ) : (
-                      <></>
-                    )}
+                    <VersionTags
+                      tags={tags[item.version]}
+                      style={{
+                        marginLeft: 8,
+                      }}
+                      max={1}
+                    />
                   </Space>
                   {isNew && !deprecated ? (
                     <span className={styles.newTag}>New</span>

--- a/src/components/VersionTags.tsx
+++ b/src/components/VersionTags.tsx
@@ -1,0 +1,71 @@
+import { Popover, Space, Tag, Tooltip } from 'antd';
+
+type VersionTagsProps = {
+  tags?: string[];
+  style?: React.CSSProperties;
+  max?: number;
+};
+
+type VersionTagProps = {
+  tag: string;
+};
+
+function VersionTag({tag}: VersionTagProps) {
+if (tag === 'latest') {
+  return (
+    <Tooltip title='默认匹配的版本' key={tag}>
+      <Tag color={'green'}>{tag}</Tag>
+    </Tooltip>
+  );
+}
+if (/latest-\d/.test(tag)) {
+  const version = tag.split('-')[1];
+  return (
+    <Tooltip
+      key={tag}
+      title={`对于 ${version}.x.x 的版本，优先返回该版本`}
+    >
+      <Tag color={'green'}>{tag}</Tag>
+    </Tooltip>
+  );
+}
+return (
+  <Tag key={tag} color='lime'>
+    {tag}
+  </Tag>
+);
+}
+
+export default function VersionTags({ tags, style, max }: VersionTagsProps) {
+  if (!tags) {
+    return <></>;
+  }
+
+  if (tags.length === 1) {
+    return <VersionTag tag={tags[0]} />;
+  }
+
+  return (
+    <div>
+      {tags.slice(0, max).map((tag) => (
+        <VersionTag key={tag} tag={tag} />
+      ))}
+      <Popover
+        placement='bottom'
+        content={
+          <Space size={'small'} direction='vertical'>
+            {tags.slice(max, tags.length - 1).map((item) => {
+              return (
+                <Tag key={item} color='lime'>
+                  {item}
+                </Tag>
+              );
+            })}
+          </Space>
+        }
+      >
+        <Tag color={'lime'}>...</Tag>
+      </Popover>
+    </div>
+  );
+}

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import SyncAlert from '@/components/SyncAlert';
 import { PageProps } from '@/pages/package/[...slug]';
 import { createStyles } from 'antd-style';
+import VersionTags from '@/components/VersionTags';
 
 const useStyles = createStyles(({ token, css }) => {
   return {
@@ -100,33 +101,7 @@ function TagsList({
                 </Link>
               </span>
               <span className={styles.dot}></span>
-              <Space size='small'>
-                {tagsInfo[item]?.map((tag) => {
-                  if (tag === 'latest') {
-                    return (
-                      <Tooltip title='默认匹配的版本' key={tag}>
-                        <Tag color={'green'}>{tag}</Tag>
-                      </Tooltip>
-                    );
-                  }
-                  if (/latest-\d/.test(tag)) {
-                    const version = tag.split('-')[1];
-                    return (
-                      <Tooltip
-                        key={tag}
-                        title={`对于 ${version}.x.x 的版本，优先返回 ${item}`}
-                      >
-                        <Tag color={'green'}>{tag}</Tag>
-                      </Tooltip>
-                    );
-                  }
-                  return (
-                    <Tag key={item} color='lime'>
-                      {tag}
-                    </Tag>
-                  );
-                })}
-              </Space>
+              <VersionTags tags={tagsInfo[item]} max={8}></VersionTags>
             </li>
           );
         })}


### PR DESCRIPTION
> 兼容 @types/default-user-agent tag 超长时，样式异常
* 🧶 添加 VersionsTags 组件，统一处理 dist-tag 渲染
* 💄 首页默认只展示1个，版本列表页展示8个

![image](https://github.com/cnpm/cnpmweb/assets/5574625/95a3edec-39d4-4c0c-968e-e14bcc3f5ccf)

![image](https://github.com/cnpm/cnpmweb/assets/5574625/d8f30f58-ead5-4580-8a95-4dc01f4d6c57)

