### PR TITLE
fix: create sync task skip cdn cache

### DIFF
--- a/src/components/Sync.tsx
+++ b/src/components/Sync.tsx
@@ -30,7 +30,7 @@ export default function Sync({ pkgName }: SyncProps) {
 
   async function doSync() {
     try {
-      const res = await fetch(`https://registry.npmmirror.com/-/package/${pkgName}/syncs`, {
+      const res = await fetch(`https://registry-direct.npmmirror.com/-/package/${pkgName}/syncs`, {
         method: 'PUT',
       }).then((res) => res.json());
       if (res.ok) {


### PR DESCRIPTION
use registry-direct.npmmirror.com

closes https://github.com/cnpm/cnpmweb/issues/26