### PR TITLE
feat: spec redirect

### DIFF
--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -68,10 +68,10 @@ export function useVersionTags(manifest: PackageManifest) {
   }, [manifest]);
 }
 
-export function useInfo(pkgName: string | undefined) {
-  return useSwr(pkgName ? `info: ${pkgName}` : null, async () => {
-    const res = await fetch(`/api/info?pkgName=${pkgName}`);
-
+export function useInfo(pkgName: string | undefined, spec: string | undefined) {
+  return useSwr(pkgName ? `info: ${pkgName}_${spec}` : null, async () => {
+    const target = `/api/info?pkgName=${pkgName || ''}&spec=${spec || ''}`;
+    const res = await fetch(target.toString());
     if (res.status === 404) {
       throw new Error(`Not Found ${pkgName}`);
     }

--- a/src/pages/api/info.ts
+++ b/src/pages/api/info.ts
@@ -6,9 +6,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
 
-    const { pkgName } = req.query;
+    const { pkgName, spec } = req.query;
 
-    const [pkg, sourceRegistryInfo] = await Promise.all([
+    const [pkg, sourceRegistryInfo, specInfo] = await Promise.all([
       fetch(`https://registry.npmmirror.com/${pkgName}`, {
         cache: 'no-store',
       }).then((res) => res.json()),
@@ -20,6 +20,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }).then(
         (res) => res.json()
       ),
+      spec ? fetch(`https://registry.npmmirror.com/${pkgName}/${spec}`, {
+        cache: 'no-store',
+      }).then(res => res.json()) : Promise.resolve({}),
     ]);
 
     // dist-tag 一致，版本也一致，就认为不需要同步
@@ -65,7 +68,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       homepage: pkg.homepage,
     };
 
-    res.status(200).json({ data, needSync: !alreadySync });
+    const version = specInfo.version || pkg?.['dist-tags']?.latest;
+
+    res.status(200).json({ data, needSync: !alreadySync, version });
   } catch (e) {
     console.error(e);
     res.status(500).json({ error: e });

--- a/src/pages/package/[...slug]/index.tsx
+++ b/src/pages/package/[...slug]/index.tsx
@@ -92,14 +92,17 @@ export default function PackagePage({
     return [getPkgName(pathGroups), getPageType(pathGroups)];
   }, [router.query]);
 
-  const { data, isLoading, error } = useInfo(pkgName);
+
+  const { data, isLoading, error } = useInfo(pkgName, router.query.version as string);
 
   const resData = data?.data;
+  const version = data?.version;
   const needSync = data?.needSync;
 
   if (error) {
     return <Result status='error' title='Error' subTitle={error?.message || '系统错误'} />;
   }
+
 
   if (isLoading || !resData?.name) {
     return (
@@ -114,8 +117,16 @@ export default function PackagePage({
     );
   }
 
-  const version =
-    (router.query.version as string) || resData?.['dist-tags']?.latest;
+  // patchVersion
+  if (router.query.version !== version) {
+    router.replace({
+      pathname: router.pathname,
+      query: {
+        slug: router.query.slug,
+        version,
+      },
+    }, undefined, { shallow: true });
+  }
 
   const Component = PageMap[type];
 


### PR DESCRIPTION
> 支持 spec 跳转

1. 🚀 支持直接输入 `/antd@^4` 形式的 spec 跳转
2. 🚄 支持 `/package/antd?version=4`，version 字段支持 spec 表达式