### PR TITLE
fix: spec redirect rerender

### DIFF
--- a/src/components/CustomTabs.tsx
+++ b/src/components/CustomTabs.tsx
@@ -32,8 +32,8 @@ export default function CustomTabs({
   pkg: PackageManifest;
 }) {
   const { push, query } = useRouter();
-
-  const targetVersion = (query.version as string) || pkg?.['dist-tags']?.latest;
+  const routerVersion = query.version as string;
+  const targetVersion = routerVersion || pkg?.['dist-tags']?.latest;
 
   return (
     <Tabs
@@ -59,7 +59,11 @@ export default function CustomTabs({
             <Link
               key={tab.key}
               shallow
-              href={`/package/${pkg.name}/${tab.key}?version=${targetVersion}`}
+              href={
+                routerVersion
+                  ? `/package/${pkg.name}/${tab.key}?version=${targetVersion}`
+                  : `/package/${pkg.name}/${tab.key}`
+              }
             >
               {tab.name}
             </Link>

--- a/src/pages/api/info.ts
+++ b/src/pages/api/info.ts
@@ -6,9 +6,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
 
-    const { pkgName, spec } = req.query;
+    const { pkgName } = req.query;
 
-    const [pkg, sourceRegistryInfo, specInfo] = await Promise.all([
+    const [pkg, sourceRegistryInfo] = await Promise.all([
       fetch(`https://registry.npmmirror.com/${pkgName}`, {
         cache: 'no-store',
       }).then((res) => res.json()),
@@ -20,9 +20,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }).then(
         (res) => res.json()
       ),
-      spec ? fetch(`https://registry.npmmirror.com/${pkgName}/${spec}`, {
-        cache: 'no-store',
-      }).then(res => res.json()) : Promise.resolve({}),
     ]);
 
     // dist-tag 一致，版本也一致，就认为不需要同步
@@ -68,9 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       homepage: pkg.homepage,
     };
 
-    const version = specInfo.version || pkg?.['dist-tags']?.latest;
-
-    res.status(200).json({ data, needSync: !alreadySync, version });
+    res.status(200).json({ data, needSync: !alreadySync });
   } catch (e) {
     console.error(e);
     res.status(500).json({ error: e });

--- a/src/pages/api/spec.ts
+++ b/src/pages/api/spec.ts
@@ -1,0 +1,27 @@
+import { PackageManifest } from "@/hooks/useManifest";
+import { isEqual } from "lodash";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+
+  try {
+
+    const { pkgName, spec } = req.query;
+
+    const [pkg] = await Promise.all([
+      fetch(`https://registry.npmmirror.com/${pkgName}/${spec}`, {
+        cache: 'no-store',
+      }).then((res) => res.json()),
+    ]);
+
+    if (!pkg.name) {
+      res.status(404).json({});
+      return;
+    }
+
+    res.status(200).json({ version: pkg.version });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: e });
+  }
+}

--- a/src/pages/package/[...slug]/index.tsx
+++ b/src/pages/package/[...slug]/index.tsx
@@ -5,7 +5,7 @@ import PageVersions from '@/slugs/versions'
 import PageDeps from '@/slugs/deps'
 import 'antd/dist/reset.css';
 import CustomTabs from '@/components/CustomTabs';
-import { PackageManifest, useInfo } from '@/hooks/useManifest';
+import { PackageManifest, useInfo, useSpec } from '@/hooks/useManifest';
 import Footer from '@/components/Footer';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
@@ -94,10 +94,11 @@ export default function PackagePage({
 
 
   const routerVersion = router.query.version as string;
-  const { data, isLoading, error } = useInfo(pkgName, router.query.version as string);
+  const { data, isLoading, error } = useInfo(pkgName);
+  const { data: specInfo } = useSpec(pkgName, routerVersion, data?.data);
 
   const resData = data?.data;
-  const version = data?.version;
+  const specVersion = specInfo?.version;
   const needSync = data?.needSync;
 
   if (error) {
@@ -119,17 +120,20 @@ export default function PackagePage({
   }
 
   // patchVersion
-  if (routerVersion && router.query.version !== version) {
+  if (routerVersion && specVersion && router.query.version !== specVersion) {
     router.replace({
       pathname: router.pathname,
       query: {
         slug: router.query.slug,
-        version,
+        version: specVersion,
       },
     }, undefined, { shallow: true });
+    return <></>;
   }
 
   const Component = PageMap[type];
+
+  const version = routerVersion || specInfo?.version || resData?.['dist-tags']?.latest;
 
   return (
     <div>

--- a/src/pages/package/[...slug]/index.tsx
+++ b/src/pages/package/[...slug]/index.tsx
@@ -93,6 +93,7 @@ export default function PackagePage({
   }, [router.query]);
 
 
+  const routerVersion = router.query.version as string;
   const { data, isLoading, error } = useInfo(pkgName, router.query.version as string);
 
   const resData = data?.data;
@@ -118,7 +119,7 @@ export default function PackagePage({
   }
 
   // patchVersion
-  if (router.query.version !== version) {
+  if (routerVersion && router.query.version !== version) {
     router.replace({
       pathname: router.pathname,
       query: {

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -174,6 +174,7 @@ function VersionsList({
                           }
                         : {}
                     }
+                    shallow
                     href={`/package/${pkg!.name}?version=${item.version}`}
                   >
                     {item.version}


### PR DESCRIPTION
> 修复 version 传入 spec 时，页面重新渲染
* 🤖 添加 /api/spec 识别单个版本，仅在无法明确查询到版本号时才发起查询
* 💄 路由参数默认隐藏 latest version
* 🐞 修复 version 变化时，页面重新发起请求