### PR TITLE
feat: manifest readme

### DIFF
--- a/src/components/ReadmeContent.tsx
+++ b/src/components/ReadmeContent.tsx
@@ -36,16 +36,16 @@ const renderer = {
 };
 marked.use({ renderer });
 
-export function ReadmeContent({ name, version = 'latest' }: { name: string; version?: string }) {
-  const content = useReadme(name, version);
+export function ReadmeContent({ name, version = 'latest', content }: { name: string; version?: string; content?: string }) {
+  const readme = useReadme(name, version, content);
   const { themeMode } = useThemeMode();
 
   const contentNode = React.useMemo(() => {
-    const loading = content === undefined;
+    const loading = readme === undefined;
     if (loading) {
       return <Skeleton active />;
     }
-    if (typeof content !== 'string') {
+    if (typeof readme !== 'string') {
       return <Result title="未查询到相关文档信息" />;
     }
     return (
@@ -53,14 +53,14 @@ export function ReadmeContent({ name, version = 'latest' }: { name: string; vers
         <div
           className={'markdown-body'}
           dangerouslySetInnerHTML={{
-            __html: marked(content, {
+            __html: marked(readme, {
               headerIds: true,
             }),
           }}
         />
       </div>
     );
-  }, [content, themeMode]);
+  }, [readme, themeMode]);
 
   useEffect(() => {
     if (location.hash) {
@@ -72,10 +72,18 @@ export function ReadmeContent({ name, version = 'latest' }: { name: string; vers
   return <Typography> {contentNode} </Typography>;
 }
 
-export default function Readme({ name, version }: { name: string; version?: string }) {
+export default function Readme({
+  name,
+  version,
+  content,
+}: {
+  name: string;
+  version?: string;
+  content?: string;
+}) {
   return (
     <SizeContainer maxWidth={800} style={{ colorScheme: 'dark' }}>
-      <ReadmeContent name={name} version={version} />
+      <ReadmeContent name={name} version={version} content={content}/>
     </SizeContainer>
   );
 }

--- a/src/hooks/useFile.ts
+++ b/src/hooks/useFile.ts
@@ -52,6 +52,9 @@ export const useDirs = (info: PkgInfo, path = '', ignore = false) => {
       return fetch(`${REGISTRY}/${info.fullname}/${info.spec}/files${path}/?meta`)
         .then((res) => res.json())
         .then((res) => {
+          if (res.error) {
+            return Promise.reject(res.error);
+          }
           sortFiles(res.files);
           return Promise.resolve(res);
         });

--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -33,6 +33,7 @@ export type PackageManifest = {
     url: string;
   };
   homepage?: string;
+  readme?: string;
 };
 
 export function useVersions(manifest: PackageManifest): NpmPackageVersion[] {

--- a/src/hooks/useReadme.ts
+++ b/src/hooks/useReadme.ts
@@ -1,8 +1,8 @@
 'use client';
 import { REGISTRY } from '@/config';
 import useSwr from 'swr';
-export function useReadme(pkgName: string, version = 'latest') {
-  const { data: content } = useSwr(pkgName ? pkgName + version : null, {
+export function useReadme(pkgName: string, version = 'latest', content?: string) {
+  const { data: readme } = useSwr((pkgName && !content) ? pkgName + version : null, {
     fetcher: async () => {
       const keys = ['README.md', 'README', 'readme.md', 'readme'];
       return Promise.all(
@@ -21,5 +21,5 @@ export function useReadme(pkgName: string, version = 'latest') {
       });
     },
   });
-  return content;
+  return readme || content;
 }

--- a/src/slugs/files/index.tsx
+++ b/src/slugs/files/index.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from '@/components/Sidebar';
 import { useDirs, File } from '@/hooks/useFile';
 import { usePathState } from '@/hooks/usePathState';
 import { PageProps } from '@/pages/package/[...slug]';
-import { Spin } from 'antd';
+import { Result, Spin } from 'antd';
 import { useState } from 'react';
 
 const Viewer = ({ manifest, version }: PageProps) => {
@@ -16,7 +16,11 @@ const Viewer = ({ manifest, version }: PageProps) => {
 
   const spec = version || 'latest';
 
-  const { data: rootDir, isLoading } = useDirs({
+  const {
+    data: rootDir,
+    isLoading,
+    error,
+  } = useDirs({
     fullname: manifest.name,
     spec,
   });
@@ -41,7 +45,9 @@ const Viewer = ({ manifest, version }: PageProps) => {
     );
   }
 
-  return (
+  return error ? (
+    <Result status="warning" title="产物预览失败" subTitle={error} />
+  ) : (
     <div style={{ display: 'flex', marginTop: -16, minHeight: '100%' }}>
       <Sidebar>
         <FileTree

--- a/src/slugs/home/index.tsx
+++ b/src/slugs/home/index.tsx
@@ -55,7 +55,7 @@ export default function Home({ manifest, version, additionalInfo: needSync }: Pa
           <AdBanner />
         </div>
         <PresetCard title="项目文档" style={{ minHeight: '100%' }}>
-          <ReadmeContent name={manifest.name} version={version} />
+          <ReadmeContent name={manifest.name} version={version} content={pkg.readme}/>
         </PresetCard>
       </Col>
       <Col flex="0 0 378px">


### PR DESCRIPTION
> 目前已请求全量 manifest 元信息 #46，可以直接使用 readme 字段 

* 优先读取 package.json 中的 readme 信息
* 针对 https://github.com/cnpm/cnpmcore/pull/695 添加报错信息展示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `ReadmeContent` component to accept and display custom content.
  - Improved `useReadme` hook to fetch README content more flexibly with an additional `content` parameter.
  - Added error handling in directory fetching for better reliability.

- **Bug Fixes**
  - Ensured proper error handling in the `useDirs` function to prevent crashes.

- **Refactor**
  - Updated `PackageManifest` type to include a `readme` field for better data consistency.

- **UI Improvements**
  - Added conditional error messages in the file directory view to inform users of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->