### PR TITLE
fix: version switch

### DIFF
--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -71,7 +71,7 @@ function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: 
         }}
       >
         <Segmented
-          value={type}
+          defaultValue={type || 'prod'}
           options={[
             { label: '正式版本', value: 'prod' },
             { label: '所有版本', value: 'all' },
@@ -131,7 +131,7 @@ function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: P
         }}
       >
         <Segmented
-          value={type}
+          defaultValue={type || 'prod'}
           options={[
             { label: '正式版本', value: 'prod' },
             { label: '所有版本', value: 'all' },


### PR DESCRIPTION
> 修复版本切换选择器失效问题
* 由于 useRouterQueryState state 更新时机不确定，导致无法更新数据，改为 defaultValue 实现

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured `TagsList` and `VersionsList` components default to `'prod'` type if no type is provided, improving reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->