### PR TITLE
fix: version switch

### DIFF
--- a/src/slugs/trends/index.tsx
+++ b/src/slugs/trends/index.tsx
@@ -12,7 +12,7 @@ const MAX_COUNT = 5;
 
 export default function Trends({ manifest: pkg }: PageProps) {
   const [search, setSearch] = useState('');
-  const [vs, setVS] = useQueryState<string>('vs', '');
+  const [vs, setVS] = useQueryState('vs', '');
   const [pkgs, setPkgs] = useState<string[]>(vs ? vs.split(',').slice(0, MAX_COUNT) : [pkg.name]);
 
   const { data: searchResult, isLoading } = useCachedSearch({

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -48,7 +48,7 @@ const useStyles = createStyles(({ token, css }) => {
 
 function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: PackageManifest }) {
   const { styles } = useStyles();
-  const [type, setTags] = useQueryState<string>('tags', 'prod', ['prod']);
+  const [type, setTags] = useQueryState('tags', 'prod');
   const onlyProd = type === 'prod';
   return (
     <div style={{ position: 'relative' }}>
@@ -71,7 +71,7 @@ function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: 
         }}
       >
         <Segmented
-          defaultValue={type || 'prod'}
+          value={type}
           options={[
             { label: '正式版本', value: 'prod' },
             { label: '所有版本', value: 'all' },
@@ -108,7 +108,7 @@ function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: 
 
 function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: PackageManifest }) {
   const { styles } = useStyles();
-  const [type, setVersions] = useQueryState<string>('versions', 'prod', ['prod']);
+  const [type, setVersions] = useQueryState('versions', 'prod');
   const onlyProd = type === 'prod';
   return (
     <div style={{ position: 'relative' }}>
@@ -131,7 +131,7 @@ function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: P
         }}
       >
         <Segmented
-          defaultValue={type || 'prod'}
+          value={type}
           options={[
             { label: '正式版本', value: 'prod' },
             { label: '所有版本', value: 'all' },


### PR DESCRIPTION
> 重构 `useQueryState` 统一使用受控模式
* 直接通过 window 对象乐观更新 query 值

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `useQueryState` hook for easier handling of URL query parameters.

- **Bug Fixes**
  - Updated state management in `TagsList` and `VersionsList` to improve consistency and reliability.

- **Style**
  - Removed redundant type annotations in the `useQueryState` function calls for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->