### PR TITLE
feat: result sync

### DIFF
--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -3,6 +3,13 @@ import useSwr from 'swr';
 import dayjs from 'dayjs';
 import { REGISTRY } from '@/config';
 
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
 export interface NpmPackageVersion {
   name: string;
   version: string;
@@ -70,7 +77,7 @@ export function useInfo(pkgName: string | undefined) {
     const target = `${REGISTRY}/${pkgName}`;
     const res = await fetch(target.toString());
     if (res.status === 404) {
-      throw new Error(`Not Found ${pkgName}`);
+      throw new NotFoundError(`Not Found ${pkgName}`);
     }
 
     if (!res.ok) {

--- a/src/pages/package/[...slug]/index.tsx
+++ b/src/pages/package/[...slug]/index.tsx
@@ -6,13 +6,14 @@ import PageTrends from '@/slugs/trends';
 import PageDeps from '@/slugs/deps';
 import 'antd/dist/reset.css';
 import CustomTabs from '@/components/CustomTabs';
-import { PackageManifest, useInfo, useSpec } from '@/hooks/useManifest';
+import { NotFoundError, PackageManifest, useInfo, useSpec } from '@/hooks/useManifest';
 import Footer from '@/components/Footer';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { Result, Spin } from 'antd';
 import Header from '@/components/Header';
 import { useTheme } from '@/hooks/useTheme';
+import Sync from '@/components/Sync';
 
 const DEFAULT_TYPE = 'home';
 const ThemeProvider = _ThemeProvider as any;
@@ -98,6 +99,16 @@ export default function PackagePage({}: {}) {
   const needSync = data?.needSync;
 
   if (error) {
+    if (error instanceof NotFoundError && pkgName) {
+      return (
+        <Result
+          status="404"
+          title={`未查询到 ${pkgName}`}
+          subTitle="这可能是由于包尚未同步到本地镜像站导致"
+          extra={<Sync pkgName={pkgName} />}
+        />
+      );
+    }
     return <Result status="error" title="Error" subTitle={error?.message || '系统错误'} />;
   }
 


### PR DESCRIPTION
> 修改 404 页展示，添加引导同步按钮，closes #95 
1. 修改 `/packages/:pkgName` 渲染逻辑，展示同步按钮
2. 直接通过 `/:pkgName`, `/:pkgName@:version` 进行访问时，会自动跳转详情页路由

![image](https://github.com/user-attachments/assets/1a255b5f-2ed5-495a-ba8f-73a8e72ae2d0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom `NotFoundError` for more specific error handling
	- Enhanced package not found error messaging with detailed user feedback

- **Bug Fixes**
	- Improved error handling for package retrieval scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->