### PR TITLE
style(version deprecated): fix deprecated version style display missing in dark mode

### DIFF
--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -154,24 +154,16 @@ function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: P
 
             return (
               <li className={styles.versionsItem} key={item.version}>
-                <span>
+                <Typography.Text delete={item.deprecated}>
                   <Link
                     prefetch={false}
                     title={item.deprecated}
-                    style={
-                      item.deprecated
-                        ? {
-                            color: 'rgba(0,0,0,.25)',
-                            textDecoration: 'line-through',
-                          }
-                        : {}
-                    }
                     shallow
                     href={`/package/${pkg!.name}?version=${item.version}`}
                   >
                     {item.version}
                   </Link>
-                </span>
+                </Typography.Text>
                 <span className={styles.dot}></span>
                 <Typography.Text type="secondary">
                   <Space size="small">


### PR DESCRIPTION
due to custom style color for deprecated item:
```css
color: rgba(0,0,0,.25)
```
in dark mode. display missing
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/2d8ffe94-6e6a-4062-a422-8f836635e54a" />
now use antd component Typography.Text delete property to fix this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the display for deprecated versions by introducing clear strikethrough styling for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->