### PR TITLE
fix: readme markdown render uncorrectly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,1 @@
 declare module 'giturl';
-declare module 'marked';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "giturl": "^2.0.0",
     "highlight.js": "^11.8.0",
     "lodash": "^4.17.21",
-    "marked": "^1.1.0",
+    "marked": "^15.0.11",
     "next": "^13.4.7",
     "npm-package-arg": "^11.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
The README file in our package has a non-compliant code block that causes markdown rendering abnormality.

![图片](https://github.com/user-attachments/assets/d278afd4-b21a-4b87-8b7a-272dd0ec6d83)

This PR upgrades marked to the latest version and fixes this problem.

Since it is a private package, it is inconvenient to provide a public link. Here is the code for the abnormal markdown rendering

```markdown
const readme = "## 使用文档\n\n1. 使用示例\n```js\nimport { Input } from 'antd'\n\n<Input onClick={(e: any) => {}}/>\n```\n\n2. 参数说明\n\n| 参数名称 | 类型   |\n| -------- | ------ |\n| env      | string |";
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Markdown rendering with improved heading anchors, link handling, and code syntax highlighting.
  - Enabled GitHub Flavored Markdown for richer content display.

- **Chores**
  - Updated the "marked" library to the latest version for improved compatibility and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->