### PR TITLE
fix: convert `*` to latest tag to avoid 404

### DIFF
--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -93,17 +93,15 @@ export function useSpec(
   info: PackageManifest | undefined,
 ) {
   // convert * to latest to avoid 404
-  if (spec === '*') {
-    spec = 'latest';
-  }
+  const normalizedSpec = spec === '*' ? 'latest' : spec;
   const needFetch = useMemo(() => {
-    return pkgName && spec && !info?.versions?.[spec];
-  }, [pkgName, spec, info]);
-  return useSwr(needFetch ? `spec: ${pkgName}_${spec}` : null, async () => {
-    const target = `${REGISTRY}/${pkgName || ''}/${spec}`;
+    return pkgName && normalizedSpec && !info?.versions?.[normalizedSpec];
+  }, [pkgName, normalizedSpec, info]);
+  return useSwr(needFetch ? `spec: ${pkgName}_${normalizedSpec}` : null, async () => {
+    const target = `${REGISTRY}/${pkgName || ''}/${normalizedSpec}`;
     const res = await fetch(target.toString());
     if (res.status === 404) {
-      throw new NotFoundError(`Not Found ${pkgName}@${spec}`);
+      throw new NotFoundError(`Not Found ${pkgName}@${normalizedSpec}`);
     }
 
     if (!res.ok) {

--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -92,6 +92,10 @@ export function useSpec(
   spec: string | undefined,
   info: PackageManifest | undefined,
 ) {
+  // convert * to latest to avoid 404
+  if (spec === '*') {
+    spec = 'latest';
+  }
   const needFetch = useMemo(() => {
     return pkgName && spec && !info?.versions?.[spec];
   }, [pkgName, spec, info]);


### PR DESCRIPTION
close https://github.com/cnpm/cnpmcore/issues/931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard package spec ('*') is now normalized to "latest" before fetching, preventing incorrect 404s.
  * Fetching logic and error messages now consistently reference the resolved "latest" spec so results and Not Found messages match expected behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->