### PR TITLE
feat: display package dist info (size, unpackedSize, fileCount)

### DIFF
--- a/src/components/LinkContnet.tsx
+++ b/src/components/LinkContnet.tsx
@@ -17,7 +17,7 @@ type LinkContentProps = {
   git?: string;
   dist?: {
     tarball: string;
-    size: string;
+    size: number;
     unpackedSize?: number;
     fileCount?: number;
   };
@@ -83,7 +83,7 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
           </Space>
         </Tooltip>
       )}
-      {dist?.unpackedSize > 0 && (
+      {dist?.unpackedSize && dist.unpackedSize > 0 && (
         <Tooltip title="解压后大小">
           <Space>
             <FolderOpenFilled />
@@ -93,7 +93,7 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
           </Space>
         </Tooltip>
       )}
-      {dist?.fileCount > 0 && (
+      {dist?.fileCount && dist.fileCount > 0 && (
         <Tooltip title="文件数量">
           <Space>
             <FileOutlined />

--- a/src/components/LinkContnet.tsx
+++ b/src/components/LinkContnet.tsx
@@ -83,7 +83,7 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
           </Space>
         </Tooltip>
       )}
-      {dist?.unpackedSize !== undefined && dist.unpackedSize > 0 && (
+      {dist?.unpackedSize > 0 && (
         <Tooltip title="解压后大小">
           <Space>
             <FolderOpenFilled />
@@ -93,7 +93,7 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
           </Space>
         </Tooltip>
       )}
-      {dist?.fileCount !== undefined && dist.fileCount > 0 && (
+      {dist?.fileCount > 0 && (
         <Tooltip title="文件数量">
           <Space>
             <FileOutlined />

--- a/src/components/LinkContnet.tsx
+++ b/src/components/LinkContnet.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Space, Typography, Tooltip } from 'antd';
 import Link from 'next/link';
 import * as gitUrl from 'giturl';
-import { FileZipFilled, HomeFilled } from '@ant-design/icons';
+import { FileZipFilled, HomeFilled, FolderOpenFilled, FileOutlined } from '@ant-design/icons';
 
 const IconGit = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 16 16">
@@ -18,6 +18,8 @@ type LinkContentProps = {
   dist?: {
     tarball: string;
     size: string;
+    unpackedSize?: number;
+    fileCount?: number;
   };
   homepage?: string;
 };
@@ -47,7 +49,7 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
           </Link>
         </Tooltip>
       )}
-      {url && (
+      {url && url !== homepage && (
         <Tooltip title="源码">
           <Link href={url} target="_blank">
             <Space>
@@ -65,10 +67,40 @@ export function LinkContent({ git, dist, homepage }: LinkContentProps) {
             <Space>
               <FileZipFilled />
               <Typography.Link ellipsis style={{ maxWidth: 358 }}>
-                {tarball.split('/').pop()}({formatFileSize(Number(dist?.size))})
+                {tarball.split('/').pop()}
               </Typography.Link>
             </Space>
           </Link>
+        </Tooltip>
+      )}
+      {dist?.size && (
+        <Tooltip title="包大小">
+          <Space>
+            <FileZipFilled />
+            <Typography.Text type="secondary">
+              Packed Size: {formatFileSize(Number(dist.size))}
+            </Typography.Text>
+          </Space>
+        </Tooltip>
+      )}
+      {dist?.unpackedSize !== undefined && dist.unpackedSize > 0 && (
+        <Tooltip title="解压后大小">
+          <Space>
+            <FolderOpenFilled />
+            <Typography.Text type="secondary">
+              Unpacked Size: {formatFileSize(dist.unpackedSize)}
+            </Typography.Text>
+          </Space>
+        </Tooltip>
+      )}
+      {dist?.fileCount !== undefined && dist.fileCount > 0 && (
+        <Tooltip title="文件数量">
+          <Space>
+            <FileOutlined />
+            <Typography.Text type="secondary">
+              Total Files: {dist.fileCount.toLocaleString()}
+            </Typography.Text>
+          </Space>
         </Tooltip>
       )}
     </Space>

--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -16,6 +16,8 @@ export interface NpmPackageVersion {
   dist?: {
     tarball: string;
     size: string;
+    unpackedSize?: number;
+    fileCount?: number;
   };
   publish_time: number | string;
   keywords: string[];

--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -15,7 +15,7 @@ export interface NpmPackageVersion {
   version: string;
   dist?: {
     tarball: string;
-    size: string;
+    size: number;
     unpackedSize?: number;
     fileCount?: number;
   };

--- a/src/slugs/home/index.tsx
+++ b/src/slugs/home/index.tsx
@@ -70,7 +70,7 @@ export default function Home({ manifest, version, additionalInfo: needSync }: Pa
               <ContributorContent members={manifest.maintainers} />
             </PresetCard>
           )}
-          <PresetCard title="相关链接">
+          <PresetCard title="资源信息">
             <LinkContent
               git={manifest.repository?.url}
               dist={manifest.versions?.[version!]?.dist}


### PR DESCRIPTION

<img width="948" height="690" alt="image" src="https://github.com/user-attachments/assets/0f27e5b1-bccc-46a3-a2cc-889dfaa563cd" />

Add detailed package distribution information to the package detail page:
- Packed Size: compressed tarball size
- Unpacked Size: extracted package size
- Total Files: number of files in the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show packed size, unpacked size, and total file count for packages, with new icons and tooltips.

* **UI/UX**
  * Display only the tarball filename in headers.
  * Only show source URL when present and not the homepage.
  * Rename links section title to "资源信息".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->