### PR TITLE
feat: Add file action button group

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.3.1",
     "semver": "^7.5.4",
-    "swr": "^2.2.0"
+    "swr": "^2.2.0",
+    "zustand": "^5.0.9"
   },
   "repository": "https://github.com/cnpm/cnpmweb.git",
   "devDependencies": {

--- a/src/components/CustomTabs.tsx
+++ b/src/components/CustomTabs.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { Tabs } from 'antd';
+import { Flex, Space, Tabs } from 'antd';
 import Link from 'next/link';
 import NPMVersionSelect from './NPMVersionSelect';
 import { PackageManifest } from '@/hooks/useManifest';
 import { useRouter } from 'next/router';
+import { FileActions } from './FileActions';
 
 const presetTabs = [
   {
@@ -44,20 +45,23 @@ export default function CustomTabs({
       activeKey={activateKey}
       type={'line'}
       tabBarExtraContent={
-        <NPMVersionSelect
-          versions={Object.keys(pkg?.versions || {})}
-          tags={pkg?.['dist-tags']}
-          targetVersion={targetVersion}
-          setVersionStr={(v) => {
-            if (v === pkg?.['dist-tags']?.latest) {
-              push(`/package/${pkg.name}/${activateKey}`, undefined, { shallow: true });
-            } else {
-              push(`/package/${pkg.name}/${activateKey}?version=${v}`, undefined, {
-                shallow: true,
-              });
-            }
-          }}
-        />
+        <Flex gap="small" style={{ marginInlineEnd: 16 }}>
+          {activateKey === 'files' && <FileActions />}
+          <NPMVersionSelect
+            versions={Object.keys(pkg?.versions || {})}
+            tags={pkg?.['dist-tags']}
+            targetVersion={targetVersion}
+            setVersionStr={(v) => {
+              if (v === pkg?.['dist-tags']?.latest) {
+                push(`/package/${pkg.name}/${activateKey}`, undefined, { shallow: true });
+              } else {
+                push(`/package/${pkg.name}/${activateKey}?version=${v}`, undefined, {
+                  shallow: true,
+                });
+              }
+            }}
+          />
+        </Flex>
       }
       items={presetTabs.map((tab) => {
         return {

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -3,6 +3,7 @@ import { Button, Space, Tooltip, message } from "antd";
 import { isEmpty } from "lodash";
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
+import { useShallow } from 'zustand/react/shallow'
 
 // #region Store
 interface IState {
@@ -29,8 +30,8 @@ const useFileActionsStore = create<IState>()(
 // ===========================================================================
 
 // #region Component
-function _FileActions() {
-  const state = useFileActionsStore();
+function InnerFileActions() {
+  const state = useFileActionsStore(useShallow(s => s));
 
   function handleCopyRaw() {
     if (!state.fileContent) return;
@@ -72,7 +73,7 @@ function _FileActions() {
   )
 }
 
-export const FileActions = Object.assign(_FileActions, {
+export const FileActions = Object.assign(InnerFileActions, {
   setStore,
   restoreStore,
 });

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -1,0 +1,79 @@
+import { CopyOutlined, DownloadOutlined } from "@ant-design/icons";
+import { Button, Space, Tooltip, message } from "antd";
+import { isEmpty } from "lodash";
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+// #region Store
+interface IState {
+  rawUrl: string;
+  fileContent: string;
+}
+
+const initialState: IState = {
+  rawUrl: '',
+  fileContent: '',
+};
+
+const setStore = (state: Partial<IState>) =>
+  useFileActionsStore.setState(state, false, 'FileActions/setStore')
+
+const restoreStore = () =>
+  useFileActionsStore.setState(initialState, false, 'FileActions/restoreStore')
+
+const useFileActionsStore = create<IState>()(
+  devtools(() => initialState, { name: 'FileActions' })
+);
+// #endregion Store
+
+// ===========================================================================
+
+// #region Component
+function _FileActions() {
+  const state = useFileActionsStore();
+
+  function handleCopyRaw() {
+    if (!state.fileContent) return;
+    navigator.clipboard.writeText(state.fileContent);
+    message.success('Copied to clipboard');
+  }
+
+  function handleDownloadRaw() {
+    if (!state.fileContent) return;
+    const blob = new Blob([state.fileContent], { type: 'text/plain' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = state.rawUrl.split('/').pop() || 'file';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  }
+
+  function handleViewRaw() {
+    if (!state.rawUrl) return;
+    window.open(state.rawUrl, '_blank', 'noopener,noreferrer');
+  }
+
+  // ========== render =========
+  if (Object.values(state).some(isEmpty)) return null
+
+  return (
+    <Space.Compact block>
+      <Button size="small" onClick={handleViewRaw}>Raw</Button>
+      <Tooltip title="Copy raw file">
+        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyRaw} />
+      </Tooltip>
+      <Tooltip title="Download raw file">
+        <Button size="small" icon={<DownloadOutlined />} onClick={handleDownloadRaw} />
+      </Tooltip>
+    </Space.Compact>
+  )
+}
+
+export const FileActions = Object.assign(_FileActions, {
+  setStore,
+  restoreStore,
+});
+// #endregion Component

--- a/src/components/NPMVersionSelect.tsx
+++ b/src/components/NPMVersionSelect.tsx
@@ -137,9 +137,11 @@ export default function NPMVersionSelect({
     return null;
   }
 
-  // 版本选择器
-  return !isEmpty(targetOptions) ? (
-    <Space style={{ paddingRight: 32 }}>
+  // ========== render ==========
+  if (isEmpty(targetOptions)) return null
+
+  return (
+    <>
       <Cascader
         size="small"
         options={targetOptions}
@@ -164,6 +166,6 @@ export default function NPMVersionSelect({
         }}
         showSearch
       />
-    </Space>
-  ) : null;
+    </>
+  )
 }

--- a/src/hooks/useFile.ts
+++ b/src/hooks/useFile.ts
@@ -63,9 +63,11 @@ export const useDirs = (info: PkgInfo, path = '', ignore = false) => {
 };
 
 export const useFileContent = (info: PkgInfo, path: string) => {
-  return useSwr(`file: ${info.fullname}_${info.spec || 'latest'}_${path}`, async () => {
-    return fetch(`${REGISTRY}/${info.fullname}/${info.spec}/files${path}`).then((res) =>
-      res.text(),
-    );
-  });
+  const swrKey = `file: ${info.fullname}_${info.spec || 'latest'}_${path}`;
+  const fileUri = `${REGISTRY}/${info.fullname}/${info.spec || 'latest'}/files${path}`;
+
+  return [
+    useSwr(swrKey, () => fetch(fileUri).then((res) => res.text())),
+    { fileUri }
+  ] as const;
 };


### PR DESCRIPTION
### 背景 or 需求

**在 npmmirror 已经开启包白名单的前提下**，我理解能在 npmmirror web 的产物预览看到的文件都默许开发者以 cdn 的方式调用。就像这样：
<img width="914" height="413" alt="image" src="https://github.com/user-attachments/assets/b48b3a44-ce76-4cf4-b746-bcd9c3a333c8" />

但是要得到这个地址是比较繁琐的：

1. 打开 npmmirror.com 
2. 然后搜索包，
3. 点击产物预览（通过这个步骤可以知道包是否允许链接的方式使用）
4. 通过左侧的目录，找到构建产物 如 `min.css` `index.js` 
5. 再通过 F12 打开控制台找到地址信息

所以，参考 GitHub 的文件页，将这个功能搬到 npmmirror web
<img width="302" height="81" alt="image" src="https://github.com/user-attachments/assets/3c2c0a2b-5908-4279-8dc9-000e8ba9bf0f" />

### 效果截图

<img width="1247" height="1215" alt="image" src="https://github.com/user-attachments/assets/4a96334c-500e-4e71-9aa6-655599d6b587" />

### 实现细节

因为 header 中组件需要得到文件信息，但是当前代码实现没有统一一个 global store。 所以临时用 zustand 方式，存储在内存中。并且最终通过 `<CodeViewer />`  注入这些信息 （CodeViewer 代表用户当前查看到文件，看起来写的比较乱，但是这个可以最小化实现。


---

另外我在实现的时候发现当前的 dark / light 主题等操作是有点问题的。所以后面再开一个新的 PR 修复。就不和当前放在一起了


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File action controls added to the code viewer: view raw, copy to clipboard, and download files.
  * File actions are now shown contextually in the tabs header when viewing files.

* **Improvements**
  * File content retrieval now exposes the file source URL alongside fetched content.
  * Minor layout adjustments to the version selector and tabs header.

* **Chores**
  * Added a state-management dependency to support the new file actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->