### PR TITLE
feat: change deps table pagination to 50 rows per page

### DIFF
--- a/src/slugs/deps/index.tsx
+++ b/src/slugs/deps/index.tsx
@@ -65,7 +65,7 @@ export default function Deps({ manifest, version }: PageProps) {
               dataSource={dependencies}
               rowKey={'package'}
               columns={columns}
-              pagination={{ size: 'small' }}
+              pagination={{ size: 'small', pageSize: 50 }}
             />
           </Card>
         </Col>
@@ -75,7 +75,7 @@ export default function Deps({ manifest, version }: PageProps) {
               dataSource={devDependencies}
               columns={columns}
               rowKey={'package'}
-              pagination={{ size: 'small' }}
+              pagination={{ size: 'small', pageSize: 50 }}
             />
           </Card>
         </Col>
@@ -85,7 +85,7 @@ export default function Deps({ manifest, version }: PageProps) {
               dataSource={optionalDependencies}
               columns={columns}
               rowKey={'package'}
-              pagination={{ size: 'small' }}
+              pagination={{ size: 'small', pageSize: 50 }}
             />
           </Card>
         </Col>


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pagination settings for dependency tables. The Dependencies, DevDependencies, and OptionalDependencies tables now display 50 rows per page by default, enhancing visibility when reviewing project dependencies. This change allows users to see more entries at once, reducing the need to navigate between multiple pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->