### PR TITLE
fix: resolve page freeze for packages with many versions

### DIFF
--- a/src/components/NPMVersionSelect.test.tsx
+++ b/src/components/NPMVersionSelect.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import NPMVersionSelect from './NPMVersionSelect';
 
 describe('NPMVersionSelect', () => {

--- a/src/components/NPMVersionSelect.test.tsx
+++ b/src/components/NPMVersionSelect.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NPMVersionSelect from './NPMVersionSelect';
+
+describe('NPMVersionSelect', () => {
+  const mockSetVersionStr = vi.fn();
+
+  beforeEach(() => {
+    mockSetVersionStr.mockClear();
+  });
+
+  describe('rendering', () => {
+    it('should render null when versions array is empty', () => {
+      const { container } = render(
+        <NPMVersionSelect
+          versions={[]}
+          targetVersion="1.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render null when targetVersion is null', () => {
+      const { container } = render(
+        <NPMVersionSelect
+          versions={['1.0.0', '1.0.1']}
+          targetVersion={null}
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render version select when versions and targetVersion are provided', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', '1.0.1', '2.0.0']}
+          targetVersion="1.0.1"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      // Should render the version selector with the target version displayed
+      expect(screen.getByText('1.0.1')).toBeInTheDocument();
+    });
+
+    it('should render tag select with tag label when version matches', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0']}
+          targetVersion="1.0.0"
+          tags={{ latest: '1.0.0' }}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      // When targetVersion matches a tag, the tag label is shown
+      expect(screen.getByTitle('latest')).toBeInTheDocument();
+    });
+  });
+
+  describe('version sorting', () => {
+    it('should sort versions in descending semver order', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', '2.0.0', '1.5.0', '10.0.0', '2.1.0']}
+          targetVersion="1.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      // The component should render with sorted versions
+      // We can verify by checking that the selected version is displayed
+      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    });
+
+    it('should handle prerelease versions', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', '1.0.1-beta.1', '1.0.1-alpha.1', '1.0.1']}
+          targetVersion="1.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    });
+
+    it('should handle invalid semver versions gracefully', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', 'invalid-version', '2.0.0']}
+          targetVersion="1.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    });
+  });
+
+  describe('tags', () => {
+    it('should show tag value when targetVersion matches a tag', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', '2.0.0']}
+          targetVersion="2.0.0"
+          tags={{ latest: '2.0.0', next: '2.0.0' }}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      // When targetVersion matches a tag, the tag select should show the version
+      expect(screen.getByText('2.0.0')).toBeInTheDocument();
+    });
+
+    it('should show placeholder when targetVersion does not match any tag', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0', '2.0.0']}
+          targetVersion="1.0.0"
+          tags={{ latest: '2.0.0' }}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(screen.getByText('选择 Tag')).toBeInTheDocument();
+    });
+
+    it('should handle empty tags object', () => {
+      render(
+        <NPMVersionSelect
+          versions={['1.0.0']}
+          targetVersion="1.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    });
+  });
+
+  describe('large version lists (performance)', () => {
+    it('should handle 1000+ versions without crashing', () => {
+      const manyVersions = Array.from({ length: 1000 }, (_, i) => {
+        const major = Math.floor(i / 100);
+        const minor = Math.floor((i % 100) / 10);
+        const patch = i % 10;
+        return `${major}.${minor}.${patch}`;
+      });
+
+      const { container } = render(
+        <NPMVersionSelect
+          versions={manyVersions}
+          targetVersion="0.0.0"
+          tags={{}}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      // Should render without crashing
+      expect(container.firstChild).not.toBeNull();
+    });
+
+    it('should handle versions with many tags', () => {
+      const versions = ['1.0.0', '2.0.0', '3.0.0'];
+      const manyTags: Record<string, string> = {};
+      for (let i = 0; i < 100; i++) {
+        manyTags[`tag-${i}`] = versions[i % versions.length];
+      }
+
+      render(
+        <NPMVersionSelect
+          versions={versions}
+          targetVersion="1.0.0"
+          tags={manyTags}
+          setVersionStr={mockSetVersionStr}
+        />
+      );
+
+      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/NPMVersionSelect.tsx
+++ b/src/components/NPMVersionSelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { isEmpty } from 'lodash';
-import { Select, Space } from 'antd';
+import { Select } from 'antd';
 import React from 'react';
 
 import semver from 'semver';

--- a/src/slugs/versions/index.test.tsx
+++ b/src/slugs/versions/index.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ReadOnlyVersions from './index';
+import { PackageManifest, NpmPackageVersion } from '@/hooks/useManifest';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => {
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+// Mock SizeContainer
+vi.mock('@/components/SizeContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Mock SyncAlert
+vi.mock('@/components/SyncAlert', () => ({
+  default: () => null,
+}));
+
+// Mock Gravatar
+vi.mock('@/components/Gravatar', () => ({
+  Gravatar: ({ name }: { name: string }) => <span data-testid="gravatar">{name}</span>,
+}));
+
+// Mock VersionTags
+vi.mock('@/components/VersionTags', () => ({
+  default: ({ tags }: { tags: string[] }) => <span data-testid="version-tags">{tags?.join(', ')}</span>,
+}));
+
+// Mock useQueryState - returns 'all' to show all versions including prereleases
+vi.mock('@/hooks/useQueryState', () => ({
+  default: () => ['all', vi.fn()],
+}));
+
+const createMockVersion = (
+  version: string,
+  publishTime: number,
+  options: Partial<NpmPackageVersion> = {}
+): NpmPackageVersion => ({
+  name: 'test-package',
+  version,
+  publish_time: publishTime,
+  keywords: [],
+  _npmUser: options._npmUser || {},
+  _cnpmcore_publish_time: new Date(publishTime).toISOString(),
+  ...options,
+});
+
+const createMockManifest = (
+  versions: NpmPackageVersion[],
+  distTags: Record<string, string> = { latest: versions[0]?.version || '1.0.0' }
+): PackageManifest => {
+  const versionsMap: Record<string, NpmPackageVersion> = {};
+  versions.forEach((v) => {
+    versionsMap[v.version] = v;
+  });
+
+  return {
+    name: 'test-package',
+    maintainers: [],
+    description: 'A test package',
+    _source_registry_name: 'npm',
+    'dist-tags': distTags,
+    versions: versionsMap,
+  };
+};
+
+describe('ReadOnlyVersions Component', () => {
+  describe('empty state', () => {
+    it('should display empty message when no versions exist', () => {
+      const manifest = createMockManifest([]);
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('暂未发布版本')).toBeInTheDocument();
+    });
+  });
+
+  describe('version list rendering', () => {
+    it('should display version records section', () => {
+      const versions = [
+        createMockVersion('1.0.0', Date.now()),
+      ];
+      const manifest = createMockManifest(versions);
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('版本记录')).toBeInTheDocument();
+    });
+
+    it('should display versions with correct links', () => {
+      const now = Date.now();
+      const versions = [
+        createMockVersion('1.0.0', now),
+        createMockVersion('2.0.0', now + 1000),
+      ];
+      // Use different versions for tags to avoid duplicate links
+      const manifest = createMockManifest(versions, { latest: '2.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Find links in the version list (not in tags list)
+      const allLinks = screen.getAllByRole('link');
+      const versionListLinks = allLinks.filter((link) =>
+        link.getAttribute('href')?.includes('?version=')
+      );
+
+      expect(versionListLinks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should sort versions by publish time descending', () => {
+      const now = Date.now();
+      const versions = [
+        createMockVersion('1.0.0', now - 2000),
+        createMockVersion('2.0.0', now),
+        createMockVersion('1.5.0', now - 1000),
+      ];
+      const manifest = createMockManifest(versions, { latest: '2.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Find version links in the versions list section
+      const allLinks = screen.getAllByRole('link');
+      const versionListLinks = allLinks.filter((link) => {
+        const href = link.getAttribute('href') || '';
+        return href.includes('?version=') && !href.includes('/home');
+      });
+
+      // Should be sorted: 2.0.0 (newest), 1.5.0, 1.0.0 (oldest)
+      expect(versionListLinks[0]).toHaveTextContent('2.0.0');
+      expect(versionListLinks[1]).toHaveTextContent('1.5.0');
+      expect(versionListLinks[2]).toHaveTextContent('1.0.0');
+    });
+
+    it('should show all versions including prerelease', () => {
+      const now = Date.now();
+      const versions = [
+        createMockVersion('1.0.0', now),
+        createMockVersion('2.0.0-beta.1', now + 1000),
+      ];
+      const manifest = createMockManifest(versions, { latest: '1.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Use getAllByText since both TagsList and VersionsList may show the prerelease version
+      expect(screen.getAllByText('2.0.0-beta.1').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('pagination', () => {
+    it('should not show pagination when versions <= 50', () => {
+      const versions = Array.from({ length: 50 }, (_, i) =>
+        createMockVersion(`1.0.${i}`, Date.now() + i * 1000)
+      );
+      const manifest = createMockManifest(versions, { latest: '1.0.49' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.queryByText(/共.*个版本/)).not.toBeInTheDocument();
+    });
+
+    it('should show pagination when versions > 50', () => {
+      const versions = Array.from({ length: 60 }, (_, i) =>
+        createMockVersion(`1.0.${i}`, Date.now() + i * 1000)
+      );
+      const manifest = createMockManifest(versions, { latest: '1.0.59' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('共 60 个版本')).toBeInTheDocument();
+    });
+
+    it('should only render 50 versions per page', () => {
+      const versions = Array.from({ length: 100 }, (_, i) =>
+        createMockVersion(`1.0.${i}`, Date.now() + i * 1000)
+      );
+      const manifest = createMockManifest(versions, { latest: '1.0.99' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Find version links in the versions list section (not tags)
+      const allLinks = screen.getAllByRole('link');
+      const versionListLinks = allLinks.filter((link) => {
+        const href = link.getAttribute('href') || '';
+        return href.includes('?version=1.0.') && !href.includes('/home');
+      });
+
+      expect(versionListLinks.length).toBe(50);
+    });
+  });
+
+  describe('tags list', () => {
+    it('should display current tags section', () => {
+      const versions = [
+        createMockVersion('1.0.0', Date.now()),
+      ];
+      const manifest = createMockManifest(versions, { latest: '1.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('当前 Tags')).toBeInTheDocument();
+    });
+
+    it('should display tag with correct link', () => {
+      const versions = [
+        createMockVersion('1.0.0', Date.now()),
+      ];
+      const manifest = createMockManifest(versions, { latest: '1.0.0', next: '1.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Tags are displayed as version links
+      const tagLinks = screen.getAllByRole('link').filter(
+        (link) => link.getAttribute('href')?.includes('/home?version=')
+      );
+      expect(tagLinks.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('large version list (performance)', () => {
+    it('should handle 1000+ versions without crashing', () => {
+      const versions = Array.from({ length: 1000 }, (_, i) => {
+        const major = Math.floor(i / 100);
+        const minor = Math.floor((i % 100) / 10);
+        const patch = i % 10;
+        return createMockVersion(`${major}.${minor}.${patch}`, Date.now() + i * 1000);
+      });
+      const manifest = createMockManifest(versions);
+
+      const startTime = performance.now();
+      render(<ReadOnlyVersions manifest={manifest} version="0.0.0" />);
+      const renderTime = performance.now() - startTime;
+
+      // Should render in under 1 second (actual should be much faster with pagination)
+      expect(renderTime).toBeLessThan(1000);
+      expect(screen.getByText('版本记录')).toBeInTheDocument();
+      expect(screen.getByText('共 1000 个版本')).toBeInTheDocument();
+    });
+  });
+
+  describe('deprecated versions', () => {
+    it('should display deprecated versions with strikethrough element', () => {
+      const versions = [
+        createMockVersion('1.0.0', Date.now(), { deprecated: 'This version is deprecated' }),
+      ];
+      const manifest = createMockManifest(versions, { latest: '1.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      // Find the link in the version list
+      const allLinks = screen.getAllByRole('link');
+      const versionLink = allLinks.find((link) => {
+        const href = link.getAttribute('href') || '';
+        return href.includes('?version=1.0.0') && !href.includes('/home');
+      });
+
+      expect(versionLink).toBeInTheDocument();
+      // Check that it's wrapped in a <del> element (strikethrough)
+      expect(versionLink?.closest('del')).toBeInTheDocument();
+    });
+  });
+
+  describe('user info', () => {
+    it('should display publisher info when available', () => {
+      const versions = [
+        createMockVersion('1.0.0', Date.now(), {
+          _npmUser: { name: 'test-user', email: 'test@example.com' },
+        }),
+      ];
+      const manifest = createMockManifest(versions, { latest: '1.0.0' });
+
+      render(<ReadOnlyVersions manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByTestId('gravatar')).toHaveTextContent('test-user');
+      expect(screen.getByText('由')).toBeInTheDocument();
+      expect(screen.getByText('发布于')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/slugs/versions/index.test.tsx
+++ b/src/slugs/versions/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import ReadOnlyVersions from './index';
 import { PackageManifest, NpmPackageVersion } from '@/hooks/useManifest';
 

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -8,7 +8,7 @@ import {
   useVersionTags,
 } from '@/hooks/useManifest';
 
-import { Card, Result, Segmented, Space, Tag, Tooltip, Typography } from 'antd';
+import { Card, Pagination, Result, Segmented, Space, Tag, Tooltip, Typography } from 'antd';
 import dayjs from 'dayjs';
 import React from 'react';
 import semver from 'semver';
@@ -50,6 +50,14 @@ function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: 
   const { styles } = useStyles();
   const [type, setTags] = useQueryState('tags', 'prod');
   const onlyProd = type === 'prod';
+
+  // Memoize filtered tags
+  const filteredTags = React.useMemo(() => {
+    return Object.keys(tagsInfo || {}).filter(
+      (item) => !onlyProd || !semver.parse(item)?.prerelease.length
+    );
+  }, [tagsInfo, onlyProd]);
+
   return (
     <div style={{ position: 'relative' }}>
       <Typography.Title
@@ -85,31 +93,48 @@ function TagsList({ tagsInfo, pkg }: { tagsInfo: Record<string, string[]>; pkg: 
           <span className={styles.dot}></span>
           <span>Tag</span>
         </li>
-        {Object.keys(tagsInfo || {}).map((item) => {
-          if (onlyProd && semver.parse(item)?.prerelease.length) {
-            return null;
-          }
-          return (
-            <li className={styles.versionsItem} key={item}>
-              <span>
-                <Link prefetch={false} href={`/package/${pkg!.name}/home?version=${item}`}>
-                  {item}
-                </Link>
-              </span>
-              <span className={styles.dot}></span>
-              <VersionTags tags={tagsInfo[item]} max={8}></VersionTags>
-            </li>
-          );
-        })}
+        {filteredTags.map((item) => (
+          <li className={styles.versionsItem} key={item}>
+            <span>
+              <Link prefetch={false} href={`/package/${pkg!.name}/home?version=${item}`}>
+                {item}
+              </Link>
+            </span>
+            <span className={styles.dot}></span>
+            <VersionTags tags={tagsInfo[item]} max={8}></VersionTags>
+          </li>
+        ))}
       </ul>
     </div>
   );
 }
 
+const PAGE_SIZE = 50;
+
 function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: PackageManifest }) {
   const { styles } = useStyles();
   const [type, setVersions] = useQueryState('versions', 'prod');
+  const [page, setPage] = React.useState(1);
   const onlyProd = type === 'prod';
+
+  // Memoize filtered and sorted versions
+  const filteredVersions = React.useMemo(() => {
+    return versions
+      .filter((item) => !onlyProd || !semver.parse(item.version)?.prerelease.length)
+      .sort((a, b) => (dayjs(a.publish_time).isAfter(b.publish_time) ? -1 : 1));
+  }, [versions, onlyProd]);
+
+  // Reset page when filter changes
+  React.useEffect(() => {
+    setPage(1);
+  }, [onlyProd]);
+
+  // Get current page items
+  const pageItems = React.useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return filteredVersions.slice(start, start + PAGE_SIZE);
+  }, [filteredVersions, page]);
+
   return (
     <div style={{ position: 'relative' }}>
       <Typography.Title
@@ -145,46 +170,50 @@ function VersionsList({ versions, pkg }: { versions: NpmPackageVersion[]; pkg: P
           <span className={styles.dot}></span>
           <span>发布信息</span>
         </li>
-        {versions
-          .sort((a, b) => (dayjs(a.publish_time).isAfter(b.publish_time) ? -1 : 1))
-          ?.map((item) => {
-            if (onlyProd && semver.parse(item.version)?.prerelease.length) {
-              return null;
-            }
-
-            return (
-              <li className={styles.versionsItem} key={item.version}>
-                <Typography.Text delete={!!item.deprecated}>
-                  <Link
-                    prefetch={false}
-                    title={item.deprecated}
-                    shallow
-                    href={`/package/${pkg!.name}?version=${item.version}`}
-                  >
-                    {item.version}
-                  </Link>
-                </Typography.Text>
-                <span className={styles.dot}></span>
-                <Typography.Text type="secondary">
-                  <Space size="small">
-                    {item._npmUser?.name ? (
-                      <>
-                        <span>由</span>
-                        <Tooltip title={item._npmUser.name.replace('buc:', '')}>
-                          <Gravatar email={item._npmUser.email} name={item._npmUser.name} />
-                        </Tooltip>
-                        <span>发布于</span>
-                      </>
-                    ) : null}
-                    <Tooltip title={dayjs(item.publish_time).format('YYYY-MM-DD HH:mm:ss Z')}>
-                      {dayjs(item.publish_time).format('YYYY-MM-DD')}
+        {pageItems.map((item) => (
+          <li className={styles.versionsItem} key={item.version}>
+            <Typography.Text delete={!!item.deprecated}>
+              <Link
+                prefetch={false}
+                title={item.deprecated}
+                shallow
+                href={`/package/${pkg!.name}?version=${item.version}`}
+              >
+                {item.version}
+              </Link>
+            </Typography.Text>
+            <span className={styles.dot}></span>
+            <Typography.Text type="secondary">
+              <Space size="small">
+                {item._npmUser?.name ? (
+                  <>
+                    <span>由</span>
+                    <Tooltip title={item._npmUser.name.replace('buc:', '')}>
+                      <Gravatar email={item._npmUser.email} name={item._npmUser.name} />
                     </Tooltip>
-                  </Space>
-                </Typography.Text>
-              </li>
-            );
-          })}
+                    <span>发布于</span>
+                  </>
+                ) : null}
+                <Tooltip title={dayjs(item.publish_time).format('YYYY-MM-DD HH:mm:ss Z')}>
+                  {dayjs(item.publish_time).format('YYYY-MM-DD')}
+                </Tooltip>
+              </Space>
+            </Typography.Text>
+          </li>
+        ))}
       </ul>
+      {filteredVersions.length > PAGE_SIZE && (
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
+          <Pagination
+            current={page}
+            pageSize={PAGE_SIZE}
+            total={filteredVersions.length}
+            onChange={setPage}
+            showSizeChanger={false}
+            showTotal={(total) => `共 ${total} 个版本`}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/slugs/versions/index.tsx
+++ b/src/slugs/versions/index.tsx
@@ -8,7 +8,7 @@ import {
   useVersionTags,
 } from '@/hooks/useManifest';
 
-import { Card, Pagination, Result, Segmented, Space, Tag, Tooltip, Typography } from 'antd';
+import { Card, Pagination, Result, Segmented, Space, Tooltip, Typography } from 'antd';
 import dayjs from 'dayjs';
 import React from 'react';
 import semver from 'semver';


### PR DESCRIPTION
close https://github.com/cnpm/cnpmweb/issues/111

Replace Cascader with virtualized Select for version selector to prevent rendering thousands of DOM nodes. Add pagination (50 per page) to versions list and memoize filtering/sorting operations to avoid expensive recomputation on every render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination for long version lists and reset page when filters change.
  * Reworked version selector to a flat, virtualized select with client-side filtering and a separate tag selector for faster, more consistent selection.

* **Tests**
  * Added comprehensive tests covering version selection, tag interactions, rendering, sorting, prerelease/invalid semver handling, pagination, and performance with large datasets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->