### PR TITLE
feat: display peerDependencies in deps page

### DIFF
--- a/src/hooks/useManifest.ts
+++ b/src/hooks/useManifest.ts
@@ -27,6 +27,7 @@ export interface NpmPackageVersion {
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
 }
 
 export type PackageManifest = {

--- a/src/slugs/deps/index.test.tsx
+++ b/src/slugs/deps/index.test.tsx
@@ -21,6 +21,7 @@ const createMockManifest = (
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
     optionalDependencies: Record<string, string>;
+    peerDependencies: Record<string, string>;
   }> = {}
 ): PackageManifest => ({
   name: 'test-package',
@@ -39,6 +40,7 @@ const createMockManifest = (
       dependencies: versionData.dependencies || {},
       devDependencies: versionData.devDependencies || {},
       optionalDependencies: versionData.optionalDependencies,
+      peerDependencies: versionData.peerDependencies,
     },
   },
 });
@@ -87,8 +89,51 @@ describe('Deps Component', () => {
     });
   });
 
+  describe('peerDependencies', () => {
+    it('should display peerDependencies section', () => {
+      const manifest = createMockManifest({
+        peerDependencies: {
+          'react': '^18.0.0',
+        },
+      });
+
+      render(<Deps manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('PeerDependencies (1)')).toBeInTheDocument();
+      expect(screen.getByText('react')).toBeInTheDocument();
+      expect(screen.getByText('^18.0.0')).toBeInTheDocument();
+    });
+
+    it('should display empty peerDependencies section when none exist', () => {
+      const manifest = createMockManifest({
+        dependencies: { 'lodash': '^4.17.21' },
+      });
+
+      render(<Deps manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('PeerDependencies (0)')).toBeInTheDocument();
+    });
+
+    it('should display multiple peerDependencies', () => {
+      const manifest = createMockManifest({
+        peerDependencies: {
+          'react': '^18.0.0',
+          'react-dom': '^18.0.0',
+          'next': '^13.0.0',
+        },
+      });
+
+      render(<Deps manifest={manifest} version="1.0.0" />);
+
+      expect(screen.getByText('PeerDependencies (3)')).toBeInTheDocument();
+      expect(screen.getByText('react')).toBeInTheDocument();
+      expect(screen.getByText('react-dom')).toBeInTheDocument();
+      expect(screen.getByText('next')).toBeInTheDocument();
+    });
+  });
+
   describe('all dependency types together', () => {
-    it('should display all three dependency types', () => {
+    it('should display all four dependency types', () => {
       const manifest = createMockManifest({
         dependencies: {
           'react': '^18.2.0',
@@ -102,6 +147,9 @@ describe('Deps Component', () => {
         optionalDependencies: {
           'fsevents': '^2.3.0',
         },
+        peerDependencies: {
+          'webpack': '^5.0.0',
+        },
       });
 
       render(<Deps manifest={manifest} version="1.0.0" />);
@@ -109,6 +157,7 @@ describe('Deps Component', () => {
       expect(screen.getByText('Dependencies (2)')).toBeInTheDocument();
       expect(screen.getByText('DevDependencies (3)')).toBeInTheDocument();
       expect(screen.getByText('OptionalDependencies (1)')).toBeInTheDocument();
+      expect(screen.getByText('PeerDependencies (1)')).toBeInTheDocument();
     });
 
     it('should handle missing version data gracefully', () => {
@@ -121,6 +170,7 @@ describe('Deps Component', () => {
       expect(screen.getByText('Dependencies (0)')).toBeInTheDocument();
       expect(screen.getByText('DevDependencies (0)')).toBeInTheDocument();
       expect(screen.getByText('OptionalDependencies (0)')).toBeInTheDocument();
+      expect(screen.getByText('PeerDependencies (0)')).toBeInTheDocument();
     });
   });
 
@@ -136,6 +186,19 @@ describe('Deps Component', () => {
 
       const link = screen.getByRole('link', { name: 'fsevents' });
       expect(link).toHaveAttribute('href', '/package/fsevents?version=%5E2.3.0');
+    });
+
+    it('should create correct links for peerDependencies', () => {
+      const manifest = createMockManifest({
+        peerDependencies: {
+          'react': '^18.0.0',
+        },
+      });
+
+      render(<Deps manifest={manifest} version="1.0.0" />);
+
+      const link = screen.getByRole('link', { name: 'react' });
+      expect(link).toHaveAttribute('href', '/package/react?version=%5E18.0.0');
     });
   });
 });

--- a/src/slugs/deps/index.tsx
+++ b/src/slugs/deps/index.tsx
@@ -32,11 +32,12 @@ const columns: TableColumnsType<DepRecord> = [
 export default function Deps({ manifest, version }: PageProps) {
   const depsInfo = React.useMemo(() => {
     const versionData = manifest.versions?.[version!];
-    if (!versionData) return { dependencies: [], devDependencies: [], optionalDependencies: [] };
+    if (!versionData) return { dependencies: [], devDependencies: [], optionalDependencies: [], peerDependencies: [] };
 
     const deps = versionData.dependencies || {};
     const devDeps = versionData.devDependencies || {};
     const optionalDeps = versionData.optionalDependencies || {};
+    const peerDeps = versionData.peerDependencies || {};
 
     return {
       dependencies: Object.entries(deps).map(([pkg, spec]) => ({
@@ -51,15 +52,19 @@ export default function Deps({ manifest, version }: PageProps) {
         package: pkg,
         spec,
       })),
+      peerDependencies: Object.entries(peerDeps).map(([pkg, spec]) => ({
+        package: pkg,
+        spec,
+      })),
     };
   }, [manifest, version]);
 
-  const { dependencies, devDependencies, optionalDependencies } = depsInfo;
+  const { dependencies, devDependencies, optionalDependencies, peerDependencies } = depsInfo;
 
   return (
     <SizeContainer maxWidth="90%">
       <Row gutter={[8, 8]}>
-        <Col span={8}>
+        <Col span={6}>
           <Card title={`Dependencies (${dependencies.length})`}>
             <Table
               dataSource={dependencies}
@@ -69,7 +74,7 @@ export default function Deps({ manifest, version }: PageProps) {
             />
           </Card>
         </Col>
-        <Col span={8}>
+        <Col span={6}>
           <Card title={`DevDependencies (${devDependencies.length})`}>
             <Table
               dataSource={devDependencies}
@@ -79,10 +84,20 @@ export default function Deps({ manifest, version }: PageProps) {
             />
           </Card>
         </Col>
-        <Col span={8}>
+        <Col span={6}>
           <Card title={`OptionalDependencies (${optionalDependencies.length})`}>
             <Table
               dataSource={optionalDependencies}
+              columns={columns}
+              rowKey={'package'}
+              pagination={{ size: 'small', pageSize: 50 }}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card title={`PeerDependencies (${peerDependencies.length})`}>
+            <Table
+              dataSource={peerDependencies}
               columns={columns}
               rowKey={'package'}
               pagination={{ size: 'small', pageSize: 50 }}


### PR DESCRIPTION
## Summary
- Add peerDependencies section to the dependencies page alongside existing dependency types
- Follow the same display pattern as optionalDependencies (added in #119)
- Adjust layout from 3 columns to 4 columns to accommodate all dependency types

## Test plan
- [x] All 35 existing tests pass
- [x] New tests added for peerDependencies display
- [ ] Manually verify peerDependencies display on packages that have them (e.g., react-dom, eslint-plugin-react)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended package metadata to include peer dependencies and added display of peer dependencies in the package view alongside other dependency types in a new dedicated column.

* **Tests**
  * Added comprehensive test coverage for peer dependency rendering, including verification of counts, item names, versions, and integration with existing dependency displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->